### PR TITLE
Update: Pylint to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
       - name: Install dependencies
-        run: poetry install        
-     # - name: Run unit tests
-    #  run: poetry run pytest src/tests
+        run: poetry install
+      - name: Run unit tests
+        run: poetry run pytest src/tests
       - name: Setup chromedriver
         uses: nanasess/setup-chromedriver@master
       - run: |


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ci.yaml` file to re-enable the unit tests step in the CI workflow.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL41-R42): Re-enabled the `Run unit tests` step by uncommenting the lines that run `poetry run pytest src/tests`.