### PR TITLE
update CI workflow to trigger on all branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ env:
 
 on:
   push:
-    branches: [main]
+    branches: 
+      - '*'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ci.yaml` file. The change modifies the `branches` configuration under the `push` event to trigger on all branches instead of just the `main` branch.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL10-R11): Updated the `branches` configuration under the `push` event to trigger on all branches.