### PR TITLE
Uudelleennimeä bibtex_parser

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -111,7 +111,7 @@ def reference_creation():
             organization,
             publisher,
         )
-        flash("Added succesfully")
+        flash("Added successfully")
         return redirect("/")
     except Exception as error:
         flash(str(error))

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ from repositories.references_repository import get_references, create_reference
 from config import app, test_env, populate_env
 from validate import validate_book, validate_article, validate_inproceedings
 from populate_test_data import populate_database
-from bibtex_parser import reference_bibtex_parser
+from bibtex_serializer import reference_bibtex_serializer
 
 
 @app.route("/")
@@ -19,7 +19,7 @@ def bibtexpreview():
     references = get_references()
     return render_template(
         "preview.html",
-        reference_list_bibtex=reference_bibtex_parser(references),
+        reference_list_bibtex=reference_bibtex_serializer(references),
     )
 
 
@@ -122,7 +122,7 @@ def reference_creation():
 @app.route("/download")
 def getBibtexFile():
     references = get_references()
-    bibtex_str = reference_bibtex_parser(references)
+    bibtex_str = reference_bibtex_serializer(references)
 
     if not bibtex_str:
         flash("There are no references to download.")

--- a/src/bibtex_serializer.py
+++ b/src/bibtex_serializer.py
@@ -1,4 +1,4 @@
-def reference_bibtex_parser(references):
+def reference_bibtex_serializer(references):
     bibtex = ""
     for i in references:
         references_dict = i.to_dict()


### PR DESCRIPTION
Sisältää seuraavat muutokset:
- luokka "reference_bibtex_**parser**" nimetty uudelleen "reference_bibtex_**serializer**"
  - "parser" viittaa yleensä objektien kokoamiseen merkkijonosta, tässä muutetaan objekti merkkijonoksi
- vastaavasti uudelleennimetty tiedosto "bibtex_parser" -> "bibtext_serializer"
- korjattu kirjoitusvirhe "succe**s**fully" -> "succe**ss**fully"